### PR TITLE
Zhang

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,14 +1,14 @@
 //接口请求函数
 import ajax from './ajax';
- const BASE = 'http://localhost:3000';
+const BASE = 'http://localhost:3000';
 
 
-export const reqLogin_username = (username, password) =>{
+export const reqLogin_username = (username, password) => {
     return ajax(
         {
             method: 'POST',
             url: BASE + '/login',
-            data:{
+            data: {
                 username,
                 password
             }
@@ -16,15 +16,50 @@ export const reqLogin_username = (username, password) =>{
     )
 }
 
-export const reqLogin_email = (email, password) =>{
+export const reqLogin_email = (email, password) => {
     return ajax(
         {
             method: 'POST',
             url: BASE + '/login',
-            data:{
+            data: {
                 email,
                 password
             }
         }
+    )
+}
+
+// 获取所有服务
+export const reqServices = (pageNum, pageSize) => {
+    return ajax(BASE + '/service/info',
+        {
+            params: {
+                pageNum,
+                pageSize
+            }
+        }
+    )
+}
+
+//搜索
+export const reqSearchServices = ({ pageNum, pageSize, searchCategory, searchCity }) => {
+    return ajax(BASE + '/service/search',
+        {
+            params: {
+                pageNum,
+                pageSize,
+            }
+        }
+    )
+}
+
+export const reqServicebyId = (serviceId) => {
+    return ajax(BASE + '/service/info',
+        {
+            params: {
+                serviceId
+            }
+        }
+
     )
 }

--- a/frontend/src/components/HeadNav/index.css
+++ b/frontend/src/components/HeadNav/index.css
@@ -1,0 +1,11 @@
+.header {
+  display: flex;
+  justify-content: space-around;
+}
+.header .header-title {
+  font-size: 30px;
+  color: #666;
+}
+.header .header-user {
+  display: flex;
+}

--- a/frontend/src/components/HeadNav/index.js
+++ b/frontend/src/components/HeadNav/index.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react'
+import { withRouter } from "react-router-dom";
+import { Layout, Button, Modal } from "antd";
+import memoryUtils from '../../utils/memoryUtils';
+import storageUtils from '../../utils/storageUtils';
+import menuList from '../../config/menuConfig';
+import './index.css'
+// 通过connect高级组件 对普通组件进行包装
+import { connect } from "react-redux";
+
+const { Header } = Layout;
+const { confirm } = Modal;
+
+
+class MHeader extends Component {
+
+  logout = () => {
+    confirm({
+      title: '确定要退出登录吗？',
+      onOk: () => {
+        storageUtils.removeUser();
+        // memoryUtils.user = {};
+        // this.props.removeUser();
+        this.props.history.replace('/home');
+      },
+      onCancel() {
+        console.log('Cancel');
+      },
+    });
+  }
+  getTitle = () => {
+    // 获取动态的标题
+    let title = '';
+    // 根据当前请求的path得到对应的title
+    const path = this.props.location.pathname;
+    menuList.forEach(item => {
+      if (item.key === path) {
+        title = item.title;
+      } else if (item.children) {
+        const cItem = item.children.find(cItem => cItem.key === path);
+        if (cItem) {
+          title = cItem.title
+        }
+      }
+    })
+    return title;
+
+  }
+
+  render() {
+    const user = memoryUtils.user;
+    // const user = this.props.user;
+    console.log(user.username + '123');  
+    console.log(this.props);
+    return (
+      <Header style={{ background: '#fff', padding: 0 }}>
+        <div className="header">
+          <h2 className='header-title'>{this.getTitle()}</h2>
+          <div className="header-user">
+            <div className='userInfo'>
+               wellcome，{user.username} {"   "}
+              <Button onClick={this.logout}>log out</Button>
+            </div>
+          </div>
+        </div>
+      </Header>
+    )
+  }
+}
+export default withRouter(MHeader);

--- a/frontend/src/components/HeadNav/index.less
+++ b/frontend/src/components/HeadNav/index.less
@@ -1,0 +1,12 @@
+.header {
+    display: flex;
+    justify-content: space-around;
+  
+    .header-title {
+      font-size: 30px;
+      color: #666;
+    }
+    .header-user{
+      display: flex;
+    }
+  }

--- a/frontend/src/components/LeftNav/index.css
+++ b/frontend/src/components/LeftNav/index.css
@@ -1,0 +1,19 @@
+.logo {
+  height: 32px;
+  margin-bottom: 50px;
+}
+.logo .left-nav-link {
+  display: flex;
+  align-items: center;
+  height: 80px;
+}
+.logo img {
+  width: 40px;
+  height: 40px;
+  margin: 0 10px;
+}
+.logo h1 {
+  color: #fff;
+  font-size: 18px;
+  margin-bottom: -5px;
+}

--- a/frontend/src/components/LeftNav/index.js
+++ b/frontend/src/components/LeftNav/index.js
@@ -1,57 +1,117 @@
 import React, { Component } from 'react'
-import { Redirect , Link } from 'react-router-dom';
+import { Redirect, Link, withRouter } from 'react-router-dom';
 import {
-  DesktopOutlined,
-  FileOutlined,
-  PieChartOutlined,
-  TeamOutlined,
-  UserOutlined,
+    DesktopOutlined,
+    FileOutlined,
+    PieChartOutlined,
+    TeamOutlined,
+    UserOutlined,
 } from '@ant-design/icons';
 import Logo from '../../assets/images/logo192.png';
 import { Breadcrumb, Layout, Menu } from 'antd';
 import './index.css'
+import menuConfig from '../../config/menuConfig'
 
 
 const { Header, Content, Footer, Sider } = Layout;
 function getItem(label, key, icon, children) {
     return {
-      key,
-      icon,
-      children,
-      label,
+        key,
+        icon,
+        children,
+        label,
     };
-  }
-
-
-export default class LeftNav extends Component {
-//将侧边栏封装到index.js中
-  render() {
-    const items = [
-        getItem('Option 1', '1', <PieChartOutlined />),
-        getItem('Option 2', '2', <DesktopOutlined />),
-        getItem('User', 'sub1', <UserOutlined />, [
-          getItem('Tom', '3'),
-          getItem('Bill', '4'),
-          getItem('Alex', '5'),
-        ]),
-        getItem('Team', 'sub2', <TeamOutlined />, [
-          getItem('Team 1', '6'), 
-          getItem('Team 2', '8')
-        ]),
-        getItem('Files', '9', <FileOutlined />),
-      ];
-    return (
-        <Sider >
-        <div className="logo">
-          <Link className='left-nav-link' to='/register'>
-            <img src={Logo} alt=""/>
-            <h1>find a service</h1>
-          </Link>
-        </div>
-        
-        <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" items={items} />
-      </Sider>
-      
-    )
-  }
 }
+// const mainMenu = [
+//     {
+//         label: 'Home',
+//         path: '/home',
+//     },
+//     {
+//         label: 'Blogs',
+//         path: '/blogs',
+//     },
+// ];
+// const items = [
+//     getItem('Home', '/home', <PieChartOutlined />),
+//     getItem('Service menu', '/menu', <DesktopOutlined />),
+//     getItem('User information', '/user', <UserOutlined />),
+//     getItem('My service', '/record', <TeamOutlined />),
+
+// ];
+// const items = mainMenu.map((item, index) => ({
+//     key: item.path,
+//     label: item.label,
+
+// }));
+
+
+class LeftNav extends Component {
+    // getMenuNodes = (menuList) => {
+    //     const path = this.props.location.pathname;
+    //     return menuList.map(item => {
+    //         if (!item.children) {
+    //             // 生成<Menu.Item>
+    //             return (
+    //                 <Menu.Item key={item.key}>
+    //                     <Link to={item.key}>
+    //                         <span>{item.title}</span>
+    //                     </Link>
+    //                 </Menu.Item>
+    //             )
+    //         }
+
+    //     })
+    // }
+    // UNSAFE_componentWillMount() {
+    //     // 会被加载一次，在render之前
+    //     this.menuNodes = this.getMenuNodes(menuConfig)
+    //   }
+
+    //将侧边栏封装到index.js中
+    render() {
+        console.log(this.props);
+        let defaultkey = this.props.location.pathname;
+        console.log(defaultkey);
+
+        return (
+            <Sider trigger={null} collapsible collapsed={this.props.collapsed}>
+                <div className="logo">
+                    <Link className='left-nav-link' to='/home'>
+                        <img src={Logo} alt="" />
+                        <h1>find a service</h1>
+                    </Link>
+                </div>
+
+                <Menu
+                    theme="dark"
+                    defaultSelectedKeys={defaultkey}
+                    mode="inline" 
+                >
+                    <Menu.Item key="/home">
+                        <DesktopOutlined />
+                        <Link to='/home'></Link>
+                        HOME
+                    </Menu.Item>
+                    <Menu.Item key="/menu">
+                    <FileOutlined/>
+                        Service menu
+                        <Link to='/menu'></Link>
+                    </Menu.Item>
+                    <Menu.Item key="/record">
+                    <TeamOutlined />
+                    My service
+                        <Link to='/record'></Link>
+                    </Menu.Item>
+                    <Menu.Item key="/user">
+                    <UserOutlined />
+                    User information
+                        <Link to='/user'></Link>
+                    </Menu.Item>
+                </Menu>
+            </Sider>
+
+        )
+    }
+}
+export default withRouter(LeftNav);

--- a/frontend/src/components/LeftNav/index.js
+++ b/frontend/src/components/LeftNav/index.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react'
+import { Redirect , Link } from 'react-router-dom';
+import {
+  DesktopOutlined,
+  FileOutlined,
+  PieChartOutlined,
+  TeamOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import Logo from '../../assets/images/logo192.png';
+import { Breadcrumb, Layout, Menu } from 'antd';
+import './index.css'
+
+
+const { Header, Content, Footer, Sider } = Layout;
+function getItem(label, key, icon, children) {
+    return {
+      key,
+      icon,
+      children,
+      label,
+    };
+  }
+
+
+export default class LeftNav extends Component {
+//将侧边栏封装到index.js中
+  render() {
+    const items = [
+        getItem('Option 1', '1', <PieChartOutlined />),
+        getItem('Option 2', '2', <DesktopOutlined />),
+        getItem('User', 'sub1', <UserOutlined />, [
+          getItem('Tom', '3'),
+          getItem('Bill', '4'),
+          getItem('Alex', '5'),
+        ]),
+        getItem('Team', 'sub2', <TeamOutlined />, [
+          getItem('Team 1', '6'), 
+          getItem('Team 2', '8')
+        ]),
+        getItem('Files', '9', <FileOutlined />),
+      ];
+    return (
+        <Sider >
+        <div className="logo">
+          <Link className='left-nav-link' to='/register'>
+            <img src={Logo} alt=""/>
+            <h1>find a service</h1>
+          </Link>
+        </div>
+        
+        <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" items={items} />
+      </Sider>
+      
+    )
+  }
+}

--- a/frontend/src/components/LeftNav/index.less
+++ b/frontend/src/components/LeftNav/index.less
@@ -1,0 +1,18 @@
+.logo{
+    height: 32px;
+    .left-nav-link{
+      display: flex;
+      align-items: center;
+      height: 80px;
+    }
+    img{
+      width: 40px;
+      height: 40px;
+      margin: 0 10px;
+    }
+    h1{
+      color:#fff;
+      font-size: 18px;
+      margin-bottom: -5px;
+    }
+  }

--- a/frontend/src/config/menuConfig.js
+++ b/frontend/src/config/menuConfig.js
@@ -1,0 +1,28 @@
+const menuList = [
+  {
+    title: 'Home', // 菜单标题名称
+    key: '/home', // 对应的path
+    icon: 'home', // 图标名称
+    public: true, // 公开的
+  },
+  {
+    title: 'Service Menu',
+    key: '/menu',
+    icon: 'appstore',
+    public: true, 
+  },
+
+  {
+    title: 'My service',
+    key: '/record',
+    icon: 'user'
+  },
+  {
+    title: 'User information',
+    key: '/user',
+    icon: 'safety',
+  },
+
+]
+
+export default menuList

--- a/frontend/src/config/useMenuRoute.js
+++ b/frontend/src/config/useMenuRoute.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react'
+import { useLocation,useNavigate } from 'antd'
+// index 为当前菜单管理的路由层级，从 1 开始
+export function useMenuRoute(index) {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  // 将 path 拆分为数组
+  // 如 /user/profile 将被拆分为 ['', 'user', 'profile']
+  const pathItems = pathname.split('/');
+  // 获取当前路由层级的 path 片段
+  const pathItem = pathItems[index] ?? '';
+
+  // 将被返回的工具函数，
+  // 该函数可设置新的菜单项的 key 并导航至相应路由
+  const setPathItem = (newItemKey) => {
+    const parentPath = pathItems.slice(0, index).join('/');
+
+    navigate(`${parentPath}/${newItemKey}`);
+  };
+
+  // 返回当前菜单项的 key 与工具函数
+  return [pathItem, setPathItem] ;
+}
+
+

--- a/frontend/src/pages/Admin/Admin.js
+++ b/frontend/src/pages/Admin/Admin.js
@@ -1,6 +1,6 @@
 import './admin.css'
 import storageUtils from '../../utils/storageUtils'
-import { Redirect , Link } from 'react-router-dom';
+import { Redirect, Link, Switch, Route , withRouter} from 'react-router-dom';
 import {
   DesktopOutlined,
   FileOutlined,
@@ -8,34 +8,32 @@ import {
   TeamOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { Breadcrumb, Layout, Menu } from 'antd';
+import { Breadcrumb, Layout, Menu, useLocation } from 'antd';
 import React, { useState } from 'react';
 import Logo from '../../assets/images/logo192.png';
 
 import LeftNav from './../../components/LeftNav/index';
+import Home from '../Home/home';
+import Servicemenu from '../ServiceMenu/servicemenu';
+import Servicerecord from '../ServiceRecord/servicerecord';
+import Userinfo from '../Userinfo/userinfo';
+import MHeader from '../../components/HeadNav/index';
+
 const { Header, Content, Footer, Sider } = Layout;
-function getItem(label, key, icon, children) {
-  return {
-    key,
-    icon,
-    children,
-    label,
-  };
-}
-const items = [
-  getItem('Option 1', '1', <PieChartOutlined />),
-  getItem('Option 2', '2', <DesktopOutlined />),
-  getItem('User', 'sub1', <UserOutlined />, [
-    getItem('Tom', '3'),
-    getItem('Bill', '4'),
-    getItem('Alex', '5'),
-  ]),
-  getItem('Team', 'sub2', <TeamOutlined />, [
-    getItem('Team 1', '6'), 
-    getItem('Team 2', '8')
-  ]),
-  getItem('Files', '9', <FileOutlined />),
-];
+// function getItem(label, key, icon, children) {
+//   return {
+//     key,
+//     icon,
+//     children,
+//     label,
+//   };
+// }
+// const items = [
+//     getItem('Home', '/home', <PieChartOutlined />),
+//     getItem('Service menu', '/menu', <DesktopOutlined />),
+//     getItem('User information', '/user', <UserOutlined />),
+//     getItem('My service', '/record', <TeamOutlined />),
+// ];
 const App = () => {
   const [collapsed, setCollapsed] = useState(false);
   const user = storageUtils.getUser();
@@ -43,44 +41,35 @@ const App = () => {
   if (!user.username) {
     return <Redirect to='/login' />
   }
+  
   return (
     <Layout
       style={{
         minHeight: '100vh',
       }}
     >
-      <LeftNav collapsible collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
-      
-      </LeftNav>
+     <LeftNav></LeftNav>
       <Layout className="site-layout">
-        <Header
+        {/* <Header
           className="site-layout-background"
           style={{
             padding: 0,
           }}
-        />
+        /> */}
+        <MHeader></MHeader>
         <Content
           style={{
-            margin: '0 16px',
+            margin: '0 0px',
           }}
         >
-          <Breadcrumb
-            style={{
-              margin: '16px 0',
-            }}
-          >
-            <Breadcrumb.Item>User</Breadcrumb.Item>
-            <Breadcrumb.Item>ab</Breadcrumb.Item>
-          </Breadcrumb>
-          <div
-            className="site-layout-background"
-            style={{
-              padding: 24,
-              minHeight: 500,
-            }}
-          >
-            Bill is a cat.
-          </div>
+          <Switch>
+            <Route path='/menu' component={Servicemenu}></Route>
+            <Route path='/home' component={Home}></Route>
+            <Route path='/record' component={Servicerecord}></Route>
+            <Route path='/user' component={Userinfo}></Route>
+            <Redirect to='/home' />
+          </Switch>
+
         </Content>
         <Footer
           style={{

--- a/frontend/src/pages/Admin/Admin.js
+++ b/frontend/src/pages/Admin/Admin.js
@@ -1,6 +1,6 @@
 import './admin.css'
 import storageUtils from '../../utils/storageUtils'
-import { Redirect } from 'react-router-dom';
+import { Redirect , Link } from 'react-router-dom';
 import {
   DesktopOutlined,
   FileOutlined,
@@ -10,6 +10,9 @@ import {
 } from '@ant-design/icons';
 import { Breadcrumb, Layout, Menu } from 'antd';
 import React, { useState } from 'react';
+import Logo from '../../assets/images/logo192.png';
+
+import LeftNav from './../../components/LeftNav/index';
 const { Header, Content, Footer, Sider } = Layout;
 function getItem(label, key, icon, children) {
   return {
@@ -27,13 +30,16 @@ const items = [
     getItem('Bill', '4'),
     getItem('Alex', '5'),
   ]),
-  getItem('Team', 'sub2', <TeamOutlined />, [getItem('Team 1', '6'), getItem('Team 2', '8')]),
+  getItem('Team', 'sub2', <TeamOutlined />, [
+    getItem('Team 1', '6'), 
+    getItem('Team 2', '8')
+  ]),
   getItem('Files', '9', <FileOutlined />),
 ];
 const App = () => {
   const [collapsed, setCollapsed] = useState(false);
   const user = storageUtils.getUser();
-    //若内存中存了用户名，则已登录，否则跳转至登录界面
+  //若内存中存了用户名，则已登录，否则跳转至登录界面
   if (!user.username) {
     return <Redirect to='/login' />
   }
@@ -43,10 +49,9 @@ const App = () => {
         minHeight: '100vh',
       }}
     >
-      <Sider collapsible collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
-        <div className="logo" />
-        <Menu theme="dark" defaultSelectedKeys={['1']} mode="inline" items={items} />
-      </Sider>
+      <LeftNav collapsible collapsed={collapsed} onCollapse={(value) => setCollapsed(value)}>
+      
+      </LeftNav>
       <Layout className="site-layout">
         <Header
           className="site-layout-background"
@@ -65,13 +70,13 @@ const App = () => {
             }}
           >
             <Breadcrumb.Item>User</Breadcrumb.Item>
-            <Breadcrumb.Item>Bill</Breadcrumb.Item>
+            <Breadcrumb.Item>ab</Breadcrumb.Item>
           </Breadcrumb>
           <div
             className="site-layout-background"
             style={{
               padding: 24,
-              minHeight: 360,
+              minHeight: 500,
             }}
           >
             Bill is a cat.
@@ -82,7 +87,7 @@ const App = () => {
             textAlign: 'center',
           }}
         >
-          Ant Design ©2018 Created by Ant UED
+          ZHW designed ©2023
         </Footer>
       </Layout>
     </Layout>

--- a/frontend/src/pages/Home/home.js
+++ b/frontend/src/pages/Home/home.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react'
+import { Breadcrumb, Layout, Menu } from 'antd';
+
+export default class Home extends Component {
+  render() {
+    return (
+      
+    <div
+      className="site-layout-background"
+      style={{
+        padding: 24,
+        minHeight: 500,
+      }}
+    >
+      home pages
+    </div>
+   
+    )
+  }
+}

--- a/frontend/src/pages/Login/Login.js
+++ b/frontend/src/pages/Login/Login.js
@@ -129,8 +129,8 @@ const App = () => {
                       message: 'user name must be shorter than 16 characters'
                     },
                     {
-                      pattern: /^[a-zA-Z\d_]+$/,
-                      message: 'Must be composed of English, numbers or underscores'
+                      pattern: /^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+$/,
+                      message: 'Must be entered a valid email address must '
                     }
                   ]}
                 >

--- a/frontend/src/pages/Login/login.css
+++ b/frontend/src/pages/Login/login.css
@@ -24,7 +24,7 @@
 }
 .login .login-content {
   width: 500px;
-  height: 350px;
+  height: 400px;
   background-color: #fff;
   margin: 100px auto;
   padding: 30px;

--- a/frontend/src/pages/ServiceMenu/detail.js
+++ b/frontend/src/pages/ServiceMenu/detail.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react'
+import { reqServicebyId } from '../../api'
+import { Card, List, Tooltip, Comment, Button } from 'antd'
+import { ArrowLeftOutlined } from '@ant-design/icons';
+// import { Comment } from '@ant-design/compatible';
+
+export default class Detail extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      service: {key: '1',
+      name: 'John Brown',
+      age: 32,
+      address: 'New York No. 1 Lake Park'
+    }
+    }
+  }
+  getService = async () => {
+    console.log(this.props.match.params.id)
+    const id = this.props.match.params.id;
+    const res = await reqServicebyId(id);
+    console.log(res);
+    if (res.status === 100) {
+      this.setState({ service: res.obj })
+    }
+  }
+  componentDidMount() {
+    this.getService();
+  }
+
+  render() {
+    const title = (
+      <span>
+        <Button
+          icon={<ArrowLeftOutlined />}
+          type='link'
+          onClick={() => {
+            this.props.history.goBack();
+          }}>
+        </Button>
+        商品详情
+      </span>
+    )
+    const {service} = this.state;
+    return (
+      <Card title={title}>
+        <List>
+          <List.Item>
+            <p>
+              <h3>service name</h3>
+              <span>{service.name}</span>
+            </p>
+          </List.Item>
+          <List.Item>
+            
+          </List.Item>
+          <List.Item>
+            
+          </List.Item>
+          <List.Item>
+            
+          </List.Item>
+          <List.Item>
+            
+          </List.Item>
+        </List>
+      </Card>
+    )
+
+  }
+}

--- a/frontend/src/pages/ServiceMenu/home.js
+++ b/frontend/src/pages/ServiceMenu/home.js
@@ -1,0 +1,356 @@
+import React, { Component } from 'react'
+import { Button, Card, Input, Select, Space, Table } from 'antd'
+import { useState } from 'react';
+import Icon from '@ant-design/icons/lib/components/Icon';
+import Link from 'antd/es/typography/Link';
+import { reqServices, reqSearchServices } from '../../api';
+import { useHistory } from 'react-router-dom'
+// const data = [
+//     {
+//       key: '1',
+//       name: 'John Brown',
+//       age: 32,
+//       address: 'New York No. 1 Lake Park',
+//     },
+//     {
+//       key: '2',
+//       name: 'Joe Black',
+//       age: 42,
+//       address: 'London No. 1 Lake Park',
+//     },
+//     {
+//       key: '3',
+//       name: 'Jim Green',
+//       age: 32,
+//       address: 'Sidney No. 1 Lake Park',
+//     },
+//     {
+//       key: '4',
+//       name: 'Jim Red',
+//       age: 32,
+//       address: 'London No. 2 Lake Park',
+//     },
+//     {
+//         key: '5',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '6',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '7',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '8',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '9',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '10',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//       {
+//         key: '11',
+//         name: 'Jim Red',
+//         age: 32,
+//         address: 'London No. 2 Lake Park',
+//       },
+//   ];
+
+const PAGE_SIZE = 5;
+const { Search } = Input;
+
+
+export default class servicemenu extends Component {
+    initColumns = () => {
+        this.columns = [
+            {
+                title: 'service name',
+                dataIndex: 'name',
+                width: '15%',
+                align: 'center'
+            },
+            {
+                title: 'description',
+                dataIndex: 'description',
+                // width: '15%',
+                align: 'center'
+            },
+            {
+                title: 'catagory',
+                dataIndex: 'catagory',
+                width: '10%',
+                align: 'center'
+            },
+            {
+                title: 'price',
+                dataIndex: 'price',
+                width: '10%',
+                align: 'center'
+            },
+            {
+                title: 'status',
+                dataIndex: 'availability',
+                width: '10%',
+                align: 'center'
+            },
+            {
+                title: 'area',
+                dataIndex: 'area',
+                width: '10%',
+                align: 'center'
+            },
+            {
+                title: 'operation',
+                align: 'center',
+                width: '10%',
+                render: (service) => {
+
+                    return (
+                        <span>
+                            <Button
+                                type="primary"
+                                onClick={() => {
+                                    console.log(service);
+                                    console.log(service.id);
+                                    console.log(this.props.history);
+                                    //跳转详情页面
+                                    this.props.history.push('/menu/detail/' + service.id);
+                                }}
+                            >details
+                            </Button>
+                        </span>
+                    )
+                }
+            }
+        ]
+    
+    }
+    
+    handleSelect = (value) => {
+        //select组件直接能传出来
+        if (typeof value === 'undefined') {
+            console.log("value" + value)
+            this.selectValue = ''
+            //这个if没任何用，我也不知道为什么undefined进不来
+        } else { this.selectValue = value }
+    }
+    handleInput = (event) => {
+        this.inputValue = event.target.value
+        //这个value要探进去找，直接传的value是个对象
+        // 万金油用法event.target.value
+        // 不能用ref.current.value，原因我也不知道
+    }
+    getSelectandInput = () => {
+
+        let select = this.selectValue
+        let input = this.inputValue
+        console.log("select", select, typeof select, "input", input, typeof input);
+
+    }
+
+    constructor() {
+        super()
+        this.state = {
+            services: [
+                {
+                    key: '1',
+                    name: 'John Brown',
+                    age: 32,
+                    address: 'New York No. 1 Lake Park',
+                    id:'asjdflkawjefl'
+                    //每个数据一个id
+                },
+                {
+                    key: '2',
+                    name: 'Joe Black',
+                    age: 42,
+                    address: 'London No. 1 Lake Park',
+                },
+                {
+                    key: '3',
+                    name: 'Jim Green',
+                    age: 32,
+                    address: 'Sidney No. 1 Lake Park',
+                },
+                {
+                    key: '4',
+                    name: 'Jim Red',
+                    age: 32,
+                    address: 'London No. 2 Lake Park',
+                },
+                {
+                    key: '5',
+                    name: 'Jim Red',
+                    age: 32,
+                    address: 'London No. 2 Lake Park',
+                },
+                {
+                    key: '6',
+                    name: 'Jim Red',
+                    age: 32,
+                    address: 'London No. 2 Lake Park',
+                },
+                {
+                    key: '7',
+                    name: 'Jim Red',
+                    age: 32,
+                    address: 'London No. 2 Lake Park',
+                },
+            ],
+            //假数据
+            total: 0 //总页数
+        }
+    }
+
+    获取分页
+    getService = async (pageNum) => {
+
+        let result;
+        if (!this.isSearch) {
+            result = await reqServices(pageNum, PAGE_SIZE);
+        } else {
+            let select = this.selectValue
+            let input = this.inputValue
+            result = await reqSearchServices({
+                pageNum,
+                pageSize: PAGE_SIZE,
+                select,
+                input
+            })
+        }
+        if (result.code === '100') {
+            const { serviceList, total } = result.obj;
+            this.setState({
+                services: serviceList,
+                total
+            })
+        }
+    }
+    componentWillMount() {
+        this.initColumns();
+      }
+
+    componentDidMount() {
+        this.getService(1);
+    }
+
+    render() {
+        const {services, total } = this.state;
+        // const onSearch = (value) => {
+        //     console.log(value)
+        //     console.log(this.state.selectType)
+        // };
+        // const {selectType} = this.state;
+        const title = (
+            <span className='abc'>
+                <Space direction="horizontal"
+                >
+                    <Select
+
+                        onChange={this.handleSelect}
+                        showSearch
+                        style={{
+                            width: 200,
+                        }}
+                        placeholder="Search by category"
+                        optionFilterProp="children"
+                        filterOption={(input, option) => (option?.label ?? '').includes(input)}
+                        filterSort={(optionA, optionB) =>
+                            (optionA?.label ?? '').toLowerCase().localeCompare((optionB?.label ?? '').toLowerCase())
+                        }
+                        options={[
+                            {
+                                value: 'All',
+                                label: 'All',
+                            },
+                            {
+                                value: 'Cleaning',
+                                label: 'Cleaning',
+                            },
+                            {
+                                value: 'Babysitting',
+                                label: 'Babysitting',
+                            },
+                            {
+                                value: 'Pest Control',
+                                label: 'Pest Control',
+                            },
+                            {
+                                value: 'Plumbing maintenance',
+                                label: 'Plumbing maintenance',
+                            },
+                            {
+                                value: 'Electrical maintenance',
+                                label: 'Electrical maintenance',
+                            },
+                            {
+                                value: 'Beauty',
+                                label: 'Beauty',
+                            },
+                        ]}
+                    />
+
+                    <Search
+                        onInput={this.handleInput}
+
+                        className='city_search'
+                        placeholder="search by city"
+                        allowClear
+                        enterButton="Search"
+                        size="medium"
+                        onSearch={this.getSelectandInput}
+                    // onSearch={() => {
+                    //     this.isSearch = true;
+                    //     //搜索标识符，true就搜索过了
+                    //     this.getService(1)
+                    // }}
+                    />
+                </Space>
+            </span>
+        )
+        return (
+            <>
+
+                <Card
+                    style={{
+                        width: '100%',
+                    }}
+                    title={title}
+                >
+                    <Table
+                        columns={this.columns}
+                        dataSource={services}
+                        pagination={{
+                            defaultPageSize: PAGE_SIZE,
+                            showQuickJumper: true,
+                            total: total,
+                            onchange: this.getService
+                        }}
+                    >
+
+                    </Table>
+                </Card>
+
+
+            </>
+        );
+    }
+};

--- a/frontend/src/pages/ServiceMenu/servicemenu.js
+++ b/frontend/src/pages/ServiceMenu/servicemenu.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react'
+import { Switch, Route, Redirect } from 'react-router-dom'
+import Home from './home'
+import Detail from './detail';
+
+
+
+
+
+export default class servicemenu extends Component {
+  render() {
+    return (
+        <Switch>
+            <Route path='/menu' exact component={Home}></Route>
+            <Route path='/menu/detail/:id' component={Detail}></Route>
+        </Switch>
+    )
+  }
+}

--- a/frontend/src/pages/ServiceRecord/servicerecord.js
+++ b/frontend/src/pages/ServiceRecord/servicerecord.js
@@ -1,0 +1,9 @@
+import React, { Component } from 'react'
+
+export default class Servicerecord extends Component {
+  render() {
+    return (
+      <div>servicerecord page</div>
+    )
+  }
+}

--- a/frontend/src/pages/Userinfo/userinfo.js
+++ b/frontend/src/pages/Userinfo/userinfo.js
@@ -1,0 +1,198 @@
+import React, { Component } from 'react'
+import { Card, Button, Select, Input, Table } from 'antd';
+// import { reqProducts, reqSearchProducts } from '../../api';
+
+const Option = Select.Option;
+const PAGE_SIZE = 4; //默认显示的一页的条数
+export default class Userinfo extends Component {
+  constructor() {
+    super()
+    this.state = {
+      searchType: 'productName',
+      searchName: '',//输入的关键字
+      total: 0,//商品总数量
+      products: [
+        {
+            key: '1',
+            name: 'John Brown',
+            age: 32,
+            address: 'New York No. 1 Lake Park',
+          },
+          {
+            key: '2',
+            name: 'Joe Black',
+            age: 42,
+            address: 'London No. 1 Lake Park',
+          },
+          {
+            key: '3',
+            name: 'Jim Green',
+            age: 32,
+            address: 'Sidney No. 1 Lake Park',
+          },
+          {
+            key: '4',
+            name: 'Jim Red',
+            age: 32,
+            address: 'London No. 2 Lake Park',
+          },
+          {
+              key: '5',
+              name: 'Jim Red',
+              age: 32,
+              address: 'London No. 2 Lake Park',
+            },
+            {
+              key: '6',
+              name: 'Jim Red',
+              age: 32,
+              address: 'London No. 2 Lake Park',
+            },
+            {
+              key: '7',
+              name: 'Jim Red',
+              age: 32,
+              address: 'London No. 2 Lake Park',
+            },
+    ],//表示商品数据
+
+    }
+  }
+  initColumns = () => {
+    this.columns = [
+      {
+        title: '商品名称',
+        width: 100,
+        dataIndex: 'name'
+      },
+      {
+        title: '商品描述',
+        dataIndex: "desc"
+      },
+      {
+        title: '价格',
+        dataIndex: "price",
+        render: price => '¥' + price
+      },
+      {
+        title: '状态',
+        render: () => {
+          return (
+            <span>
+              <Button>上架</Button>
+              <span>在售</span>
+            </span>
+          )
+        }
+      },
+      {
+        title: '操作',
+        render: (product) => {
+          return (
+            <span>
+              <Button type='link' onClick={() => {
+                // 跳转详情页面
+                this.props.history.push('/product/detail/' + product._id);
+              }}>详情</Button>
+              <Button type='link' onClick={() => {
+                // 跳转修改页面
+                this.props.history.push({
+                  pathname: '/product/addUpdate',
+                  search:'?productId='+product._id
+                });
+              }}>修改</Button>
+            </span>
+          )
+        }
+      }
+    ]
+  }
+  getProducts = async (pageNum) => {
+    const { searchName, searchType } = this.state;
+    let result;
+    // if (!this.isSearch) {
+    //   result = await reqProducts(pageNum, PAGE_SIZE);
+    // } else {
+    //   // 要搜索
+    //   result = await reqSearchProducts({
+    //     pageNum,
+    //     pageSize: PAGE_SIZE,
+    //     searchType,
+    //     searchName
+    //   })
+    // }
+
+    // if (result.status === 0) {
+    //   const { list, total } = result.data;
+    //   this.setState({
+    //     total,
+    //     products: list
+    //   })
+    // }
+  }
+  componentWillMount() {
+    this.initColumns();
+  }
+  componentDidMount() {
+    // 获取第一页的商品数据
+    this.getProducts(1);
+  }
+  render() {
+    const { searchType, searchName, products, total } = this.state;
+    const extra = (
+      <Button type='primary' onClick={() => {
+        this.props.history.push('/product/addUpdate');
+      }}>
+
+        添加商品
+      </Button>
+    )
+    const title = (
+      <span>
+        <Select value={searchType} style={{ width: 200 }} onChange={value => this.setState({ searchType: value })}>
+          <Option value='productName'>按名称搜索</Option>
+          <Option value='productDesc'>按描述搜索</Option>
+        </Select>
+        <Input
+          placeholder='关键字'
+          style={{ width: 200, margin: '0 10px' }}
+          value={searchName}
+          onChange={e => this.setState({ searchName: e.target.value })}
+        />
+        <Button type='primary' onClick={() => {
+          // 搜索的操作
+          this.isSearch = true;//表示搜索了
+          // 获取搜索的商品
+          this.getProducts(1)
+
+        }}>
+          搜索
+        </Button>
+
+      </span>
+    )
+    return (
+      <Card
+        title={title}
+        extra={extra}
+      >
+        <Table
+          bordered
+          columns={this.columns}
+          dataSource={products}
+          rowKey='_id'
+
+          pagination={{
+            total,
+            defaultPageSize: PAGE_SIZE,
+            showQuickJumper: true,
+            onChange: this.getProducts
+          }}
+        >
+
+        </Table>
+
+      </Card>
+    )
+  }
+}

--- a/frontend/src/utils/memoryUtils.js
+++ b/frontend/src/utils/memoryUtils.js
@@ -1,0 +1,7 @@
+import storageUtils from "./storageUtils";
+
+// 内存 提高运行效率 将来要换成 redux
+export default {
+  // 用来存储登录用户的信息 初始值为local中读取的user
+  user:storageUtils.getUser(),
+}


### PR DESCRIPTION
menu页完成，详情页回退路由完成

head栏封装完成，实现logout与显示当前left栏

left栏封装完成，实现选中跟随选择不因返回改变

menu页使用的勾子办法有很多，随便选一种用就行，一种不行换另一种，ref少用，我们的antd版本太高很多组件把原生组件层层包裹（比如input）搞了很久都拿不到。
最简单的一种就下面这样
constructor{
super（）
this.state{
数据初始化
}
}

写个函数获取后台返回的数据（）{
if（res.code=100(我们后端数据就是返回成功code为100)）
设几个参数等于后端拿到的数据
this.setstate
数据=参数
}

然后render里写组件
render（）{
const {先把数据拿出来 } = this.state;
然后组件里面
<比如card
datasourse =新鲜拿到的数据
>
</card>
}